### PR TITLE
Fixed seed finder timer

### DIFF
--- a/seeder/src/pages/Seeder.js
+++ b/seeder/src/pages/Seeder.js
@@ -206,6 +206,7 @@ export default function Seeder() {
         if (range > 0) {
             setIsFindingSeed(true);
             setFindingSeedStartTime(new Date());
+            setFindingSeedDuration(0);
             setSeedFindingSpeed(0);
             const start = new Date();
             let events = 0;


### PR DESCRIPTION
Fixed the timer in the seed finder to show "You have been searching for 0s" at the start instead of whatever number the timer was at the end of the previous search